### PR TITLE
Update API.swift

### DIFF
--- a/ElasticSearch/ElasticSearch/API.swift
+++ b/ElasticSearch/ElasticSearch/API.swift
@@ -81,7 +81,7 @@ class API: NSObject {
                 return
             }
             
-            if let httpStatus = response as? HTTPURLResponse, httpStatus.statusCode >= NetworkError.Success.code{
+            if let httpStatus = response as? HTTPURLResponse, httpStatus.statusCode != NetworkError.Success.code{
                 
                 
                 


### PR DESCRIPTION
Line no 84 has incorrect condition around success code check. It should not have "=" as this will result in error even if the success code returned by server is 200. It should be "!=". The same has been fixed with this pull request.